### PR TITLE
fix(rewards): guard _normalize_numeric against infinity and NaN

### DIFF
--- a/src/alignrl/rewards.py
+++ b/src/alignrl/rewards.py
@@ -53,13 +53,17 @@ def extract_answer(text: str) -> str | None:
 
 def _normalize_numeric(s: str) -> str | None:
     """Try to parse as a number for comparison."""
+    import math
+
     s = s.strip().rstrip(".")
     try:
         val = float(s)
+        if not math.isfinite(val):
+            return None
         if val == int(val):
             return str(int(val))
         return str(val)
-    except ValueError:
+    except (ValueError, OverflowError):
         return None
 
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -114,6 +114,14 @@ class TestNormalizeNumeric:
     def test_trailing_dot(self) -> None:
         assert _normalize_numeric("42.") == "42"
 
+    def test_infinity_returns_none(self) -> None:
+        assert _normalize_numeric("inf") is None
+        assert _normalize_numeric("infinity") is None
+        assert _normalize_numeric("-inf") is None
+
+    def test_nan_returns_none(self) -> None:
+        assert _normalize_numeric("nan") is None
+
 
 class TestAnswersMatch:
     def test_exact_match(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `math.isfinite()` check before attempting `int(val)` conversion in `_normalize_numeric`
- Catches `OverflowError` alongside `ValueError` for robustness
- Prevents training crash when model outputs "inf", "infinity", or "nan" as answers

Fixes #5

## Test plan
- [x] New test: `test_infinity_returns_none` for inf/-inf
- [x] New test: `test_nan_returns_none`
- [x] All 147 tests pass