### PR TITLE
fix(inference): use vLLM chat() API instead of raw str(messages)

### DIFF
--- a/src/alignrl/inference.py
+++ b/src/alignrl/inference.py
@@ -97,7 +97,7 @@ class ModelServer:
             max_tokens=self.config.max_tokens,
             top_p=self.config.top_p,
         )
-        outputs = self._model.generate([str(messages)], params)
+        outputs = self._model.chat(messages, sampling_params=params)
         return outputs[0].outputs[0].text
 
     def _generate_mlx(self, messages: list[dict[str, str]]) -> str:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -136,12 +136,16 @@ class TestModelServer:
 
         mock_output = MagicMock()
         mock_output.outputs = [MagicMock(text="vllm result")]
-        server._model.generate.return_value = [mock_output]
+        server._model.chat.return_value = [mock_output]
 
+        messages = [{"role": "user", "content": "hi"}]
         mock_vllm = MagicMock()
         with patch.dict("sys.modules", {"vllm": mock_vllm}):
-            result = server._generate_vllm([{"role": "user", "content": "hi"}])
+            result = server._generate_vllm(messages)
             assert result == "vllm result"
+            server._model.chat.assert_called_once()
+            call_args = server._model.chat.call_args
+            assert call_args[0][0] == messages
 
     def test_generate_mlx(self) -> None:
         cfg = InferenceConfig(backend="mlx")


### PR DESCRIPTION
## Summary

- Replaces `self._model.generate([str(messages)], params)` with `self._model.chat(messages, sampling_params=params)`
- `str(messages)` produced a Python dict repr like `"[{'role': 'user', ...}]"` as raw text, making the vLLM backend completely non-functional
- vLLM's `chat()` API natively handles message lists and applies the model's chat template

Fixes #7

## Test plan
- [x] Updated `test_generate_vllm` to verify `chat()` is called with correct messages
- [x] All 147 tests pass