### PR TITLE
fix(data): use 'is not None' for dataset_size check in all runners

### DIFF
--- a/src/alignrl/dpo.py
+++ b/src/alignrl/dpo.py
@@ -62,7 +62,7 @@ class DPORunner:
         from datasets import load_dataset
 
         ds = load_dataset(self.config.dataset_name, split=self.config.dataset_split)
-        if self.config.dataset_size:
+        if self.config.dataset_size is not None:
             ds = ds.select(range(min(self.config.dataset_size, len(ds))))
         return ds.map(format_ultrafeedback)
 

--- a/src/alignrl/grpo.py
+++ b/src/alignrl/grpo.py
@@ -88,7 +88,7 @@ class GRPORunner:
             self.config.dataset_config,
             split=self.config.dataset_split,
         )
-        if self.config.dataset_size:
+        if self.config.dataset_size is not None:
             ds = ds.select(range(min(self.config.dataset_size, len(ds))))
         return ds.map(_format_gsm8k_prompt, remove_columns=ds.column_names)
 

--- a/src/alignrl/sft.py
+++ b/src/alignrl/sft.py
@@ -63,7 +63,7 @@ class SFTRunner:
         from datasets import load_dataset
 
         ds = load_dataset(self.config.dataset_name, split=self.config.dataset_split)
-        if self.config.dataset_size:
+        if self.config.dataset_size is not None:
             ds = ds.select(range(min(self.config.dataset_size, len(ds))))
 
         def _apply_template(example):

--- a/tests/test_dpo.py
+++ b/tests/test_dpo.py
@@ -124,6 +124,22 @@ class TestDPORunner:
             runner._load_dataset()
             mock_ds.select.assert_not_called()
 
+    def test_load_dataset_size_zero_selects(self) -> None:
+        cfg = DPOConfig(dataset_size=0)
+        runner = DPORunner(cfg)
+
+        mock_ds = MagicMock()
+        mock_ds.__len__ = MagicMock(return_value=100)
+        mock_ds.select.return_value = mock_ds
+        mock_ds.map.return_value = mock_ds
+
+        mock_datasets = MagicMock()
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        with patch.dict("sys.modules", {"datasets": mock_datasets}):
+            runner._load_dataset()
+            mock_ds.select.assert_called_once_with(range(0))
+
     def test_train(self, tmp_path: Path) -> None:
         cfg = DPOConfig(output_dir=str(tmp_path / "dpo_output"))
         runner = DPORunner(cfg)


### PR DESCRIPTION
## Summary

- Changes `if self.config.dataset_size:` to `if self.config.dataset_size is not None:` in SFT, DPO, and GRPO runners
- `dataset_size=0` was silently treated as `None`, loading the full dataset instead of an empty one
- Consistent fix across all three runner implementations

Fixes #9

## Test plan
- [x] New test: `test_load_dataset_size_zero_selects` verifies `select(range(0))` is called
- [x] All 148 tests pass