### PR TITLE
perf(rewards): pre-compile regex patterns at module level

### DIFF
--- a/src/alignrl/rewards.py
+++ b/src/alignrl/rewards.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import math
 import re
+
+_RE_ANSWER = re.compile(r"(?:the answer is|answer:)\s*([^\s.,]+)", re.IGNORECASE)
+_RE_EQUALS = re.compile(r"=\s*([^\s.,=]+)")
 
 
 def _extract_boxed_contents(text: str) -> list[str]:
@@ -40,11 +44,11 @@ def extract_answer(text: str) -> str | None:
     if boxed:
         return boxed[-1].strip()
 
-    answer_match = re.findall(r"(?:the answer is|answer:)\s*([^\s.,]+)", text, re.IGNORECASE)
+    answer_match = _RE_ANSWER.findall(text)
     if answer_match:
         return answer_match[-1].strip()
 
-    eq_match = re.findall(r"=\s*([^\s.,=]+)", text)
+    eq_match = _RE_EQUALS.findall(text)
     if eq_match:
         return eq_match[-1].strip()
 
@@ -53,8 +57,6 @@ def extract_answer(text: str) -> str | None:
 
 def _normalize_numeric(s: str) -> str | None:
     """Try to parse as a number for comparison."""
-    import math
-
     s = s.strip().rstrip(".")
     try:
         val = float(s)


### PR DESCRIPTION
## Summary

- Moves regex patterns from inline `re.findall()` to pre-compiled module-level constants `_RE_ANSWER` and `_RE_EQUALS`
- Moves `import math` from inside `_normalize_numeric` to module level
- Eliminates redundant `re.compile()` calls on every reward function invocation

Fixes #13

## Test plan
- [x] All 149 tests pass with identical behavior
- [x] Benchmarked: pre-compiled patterns run at same speed (already fast) but avoid per-call compilation overhead