### PR TITLE
fix(sft): use processing_class instead of deprecated tokenizer param

### DIFF
--- a/src/alignrl/sft.py
+++ b/src/alignrl/sft.py
@@ -104,7 +104,7 @@ class SFTRunner:
 
         trainer = SFTTrainer(
             model=self._model,
-            tokenizer=self._tokenizer,
+            processing_class=self._tokenizer,
             train_dataset=dataset,
             args=training_args,
         )


### PR DESCRIPTION
## Summary

- Changes `tokenizer=self._tokenizer` to `processing_class=self._tokenizer` in SFTTrainer init
- Matches DPOTrainer and GRPOTrainer which already use the correct parameter name
- Eliminates deprecation warning visible in notebook output

Fixes #15

## Test plan
- [x] All 149 tests pass