### PR TITLE
fix(types): widen TrainResult.metrics to dict[str, Any]

### DIFF
--- a/src/alignrl/types.py
+++ b/src/alignrl/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -15,7 +15,7 @@ class TrainResult:
 
     output_dir: Path
     loss_history: list[float]
-    metrics: dict[str, float]
+    metrics: dict[str, Any]
     num_steps: int
     num_epochs: float
 


### PR DESCRIPTION
## Summary

- Changes `TrainResult.metrics` from `dict[str, float]` to `dict[str, Any]`
- GRPO stores `reward_history: list[float]` in metrics, violating the `dict[str, float]` contract
- Fixes mypy strict mode violations and incorrect IDE type hints

Fixes #17

## Test plan
- [x] All 149 tests pass