### PR TITLE
fix(config): correct from_yaml return type and handle empty YAML files

### DIFF
--- a/src/alignrl/config.py
+++ b/src/alignrl/config.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 class BaseTrainConfig(BaseModel):
@@ -37,10 +41,10 @@ class BaseTrainConfig(BaseModel):
     load_in_4bit: bool = True
 
     @classmethod
-    def from_yaml(cls, path: Path) -> BaseTrainConfig:
+    def from_yaml(cls, path: Path) -> Self:
         with open(path) as f:
             data = yaml.safe_load(f)
-        return cls(**data)
+        return cls(**(data or {}))
 
 
 # ChatML template used as fallback when the tokenizer doesn't have one set.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,18 @@ class TestBaseTrainConfig:
         assert cfg.model_name == "partial-model"
         assert cfg.learning_rate == 2e-4  # default preserved
 
+    def test_from_yaml_empty_file(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "empty.yaml"
+        yaml_path.write_text("")
+        cfg = BaseTrainConfig.from_yaml(yaml_path)
+        assert cfg.model_name == "Qwen/Qwen2.5-3B"  # all defaults
+
+    def test_from_yaml_empty_doc(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "empty_doc.yaml"
+        yaml_path.write_text("---\n")
+        cfg = BaseTrainConfig.from_yaml(yaml_path)
+        assert cfg.model_name == "Qwen/Qwen2.5-3B"
+
     def test_output_dir_is_path(self) -> None:
         cfg = BaseTrainConfig(output_dir="./my-output")
         assert isinstance(cfg.output_dir, Path)


### PR DESCRIPTION
## Summary

- Changes `from_yaml` return annotation from `BaseTrainConfig` to `Self` (fixes mypy strict + notebook IDE autocomplete)
- Guards against `yaml.safe_load()` returning `None` for empty YAML files with `(data or {})`, returning all defaults instead of crashing with confusing `TypeError`

Fixes #19

## Test plan
- [x] New test: `test_from_yaml_empty_file` for empty file
- [x] New test: `test_from_yaml_empty_doc` for YAML with only `---`
- [x] All 151 tests pass