### PR TITLE
fix(inference): pass LoRA adapter to vLLM via LoRARequest

### DIFF
--- a/src/alignrl/inference.py
+++ b/src/alignrl/inference.py
@@ -32,6 +32,7 @@ class ModelServer:
         self.config = config
         self._model = None
         self._tokenizer = None
+        self._lora_request = None
 
     def load(self) -> None:
         if self.config.backend == "vllm":
@@ -60,7 +61,14 @@ class ModelServer:
 
         kwargs = {"model": self.config.model_name, "dtype": "auto"}
         if self.config.adapter_path:
+            from vllm.lora.request import LoRARequest
+
             kwargs["enable_lora"] = True
+            self._lora_request = LoRARequest(
+                lora_name="adapter",
+                lora_int_id=1,
+                lora_path=self.config.adapter_path,
+            )
         self._model = LLM(**kwargs)
 
     def _load_mlx(self) -> None:
@@ -97,7 +105,10 @@ class ModelServer:
             max_tokens=self.config.max_tokens,
             top_p=self.config.top_p,
         )
-        outputs = self._model.chat(messages, sampling_params=params)
+        kwargs = {"sampling_params": params}
+        if self._lora_request:
+            kwargs["lora_request"] = self._lora_request
+        outputs = self._model.chat(messages, **kwargs)
         return outputs[0].outputs[0].text
 
     def _generate_mlx(self, messages: list[dict[str, str]]) -> str:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -102,10 +102,12 @@ class TestModelServer:
         server = ModelServer(cfg)
 
         mock_vllm = MagicMock()
-        with patch.dict("sys.modules", {"vllm": mock_vllm}):
+        mock_lora_mod = MagicMock()
+        with patch.dict("sys.modules", {"vllm": mock_vllm, "vllm.lora.request": mock_lora_mod}):
             server._load_vllm()
             call_kwargs = mock_vllm.LLM.call_args[1]
             assert call_kwargs["enable_lora"] is True
+            assert server._lora_request is not None
 
     def test_load_vllm_without_adapter(self) -> None:
         cfg = InferenceConfig(backend="vllm", adapter_path=None)
@@ -116,6 +118,7 @@ class TestModelServer:
             server._load_vllm()
             call_kwargs = mock_vllm.LLM.call_args[1]
             assert "enable_lora" not in call_kwargs
+            assert server._lora_request is None
 
     def test_load_mlx(self) -> None:
         cfg = InferenceConfig(backend="mlx", model_name="test-model")
@@ -146,6 +149,24 @@ class TestModelServer:
             server._model.chat.assert_called_once()
             call_args = server._model.chat.call_args
             assert call_args[0][0] == messages
+
+    def test_generate_vllm_with_lora(self) -> None:
+        cfg = InferenceConfig(backend="vllm")
+        server = ModelServer(cfg)
+        server._model = MagicMock()
+        server._lora_request = MagicMock()
+
+        mock_output = MagicMock()
+        mock_output.outputs = [MagicMock(text="lora result")]
+        server._model.chat.return_value = [mock_output]
+
+        messages = [{"role": "user", "content": "hi"}]
+        mock_vllm = MagicMock()
+        with patch.dict("sys.modules", {"vllm": mock_vllm}):
+            result = server._generate_vllm(messages)
+            assert result == "lora result"
+            call_kwargs = server._model.chat.call_args[1]
+            assert "lora_request" in call_kwargs
 
     def test_generate_mlx(self) -> None:
         cfg = InferenceConfig(backend="mlx")


### PR DESCRIPTION
## Summary

- Creates a `LoRARequest` during `_load_vllm` when `adapter_path` is set
- Passes the `LoRARequest` to `chat()` during generation
- Previously, `enable_lora=True` was set but the adapter path was never passed, so the adapter was silently ignored and base model outputs were returned

Fixes #21

## Test plan
- [x] New test: `test_generate_vllm_with_lora` verifies lora_request is passed to chat()
- [x] Updated `test_load_vllm_with_adapter` to verify lora_request is created
- [x] Updated `test_load_vllm_without_adapter` to verify lora_request is None
- [x] All 152 tests pass