### PR TITLE
fix(grpo): use 'is not None' for reward_weights check

### DIFF
--- a/src/alignrl/grpo.py
+++ b/src/alignrl/grpo.py
@@ -120,7 +120,7 @@ class GRPORunner:
             save_strategy="steps",
             save_steps=50,
         )
-        if self.config.reward_weights:
+        if self.config.reward_weights is not None:
             grpo_args.reward_weights = self.config.reward_weights
 
         trainer = GRPOTrainer(


### PR DESCRIPTION
## Summary

- Changes `if self.config.reward_weights:` to `if self.config.reward_weights is not None:`
- Same falsy-check pattern as the dataset_size bug fixed in #9

Fixes #23

## Test plan
- [x] All 152 tests pass