### PR TITLE
fix(runners): call ensure_chat_template in load() for all runners

### DIFF
--- a/src/alignrl/dpo.py
+++ b/src/alignrl/dpo.py
@@ -134,3 +134,4 @@ class DPORunner:
             max_seq_length=self.config.max_seq_length,
             load_in_4bit=self.config.load_in_4bit,
         )
+        ensure_chat_template(self._tokenizer)

--- a/src/alignrl/grpo.py
+++ b/src/alignrl/grpo.py
@@ -173,3 +173,4 @@ class GRPORunner:
             max_seq_length=self.config.max_seq_length,
             load_in_4bit=self.config.load_in_4bit,
         )
+        ensure_chat_template(self._tokenizer)

--- a/src/alignrl/sft.py
+++ b/src/alignrl/sft.py
@@ -141,3 +141,4 @@ class SFTRunner:
             max_seq_length=self.config.max_seq_length,
             load_in_4bit=self.config.load_in_4bit,
         )
+        ensure_chat_template(self._tokenizer)


### PR DESCRIPTION
## Summary

- Adds `ensure_chat_template(self._tokenizer)` to `load()` in SFTRunner, DPORunner, and GRPORunner
- `_load_model()` already calls this, but `load()` was missing it
- Fixes the common notebook pattern: train -> save -> reload -> inference fails with missing chat template

Fixes #25

## Test plan
- [x] All 152 tests pass