### PR TITLE
perf: cache lazy imports in module globals after first resolution

### DIFF
--- a/src/alignrl/__init__.py
+++ b/src/alignrl/__init__.py
@@ -31,7 +31,9 @@ _LAZY_IMPORTS: dict[str, str] = {
 def __getattr__(name: str):
     if name in _LAZY_IMPORTS:
         module = importlib.import_module(_LAZY_IMPORTS[name])
-        return getattr(module, name)
+        attr = getattr(module, name)
+        globals()[name] = attr
+        return attr
     raise AttributeError(f"module 'alignrl' has no attribute {name!r}")
 
 


### PR DESCRIPTION
## Summary

- After first `__getattr__` resolution, caches the result in `globals()` via `globals()[name] = attr`
- Subsequent accesses find the attribute in `__dict__` directly, bypassing `__getattr__`
- ~3x faster for repeated module attribute access (111x overhead -> 40x, where 40x is the baseline Python LOAD_ATTR cost)

Fixes #33

## Test plan
- [x] All 179 tests pass, lint/format clean