### PR TITLE
fix(runners): guard against empty loss_history in all trainers

### DIFF
--- a/src/alignrl/dpo.py
+++ b/src/alignrl/dpo.py
@@ -106,6 +106,8 @@ class DPORunner:
         trainer.save_model(str(output_dir / "final"))
 
         loss_history = [log["loss"] for log in trainer.state.log_history if "loss" in log]
+        if not loss_history:
+            loss_history = [result.training_loss]
 
         train_result = TrainResult(
             output_dir=output_dir / "final",

--- a/src/alignrl/grpo.py
+++ b/src/alignrl/grpo.py
@@ -135,6 +135,8 @@ class GRPORunner:
         trainer.save_model(str(output_dir / "final"))
 
         loss_history = [log["loss"] for log in trainer.state.log_history if "loss" in log]
+        if not loss_history:
+            loss_history = [result.training_loss]
         reward_history = [
             log.get("reward", 0.0) for log in trainer.state.log_history if "reward" in log
         ]

--- a/src/alignrl/sft.py
+++ b/src/alignrl/sft.py
@@ -113,6 +113,8 @@ class SFTRunner:
         trainer.save_model(str(output_dir / "final"))
 
         loss_history = [log["loss"] for log in trainer.state.log_history if "loss" in log]
+        if not loss_history:
+            loss_history = [result.training_loss]
 
         train_result = TrainResult(
             output_dir=output_dir / "final",


### PR DESCRIPTION
## Summary

- Adds `if not loss_history: loss_history = [result.training_loss]` fallback in SFT, DPO, and GRPO train methods
- Prevents IndexError when `max_steps < logging_steps` produces no log entries with loss
- Common in notebooks with small training runs (max_steps=1)

Fixes #35

## Test plan
- [x] All 179 tests pass, lint/format clean